### PR TITLE
fix: default poll_interval for legacy config entries

### DIFF
--- a/custom_components/smarthub/__init__.py
+++ b/custom_components/smarthub/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.exceptions import ConfigEntryError
 
 from .api import SmartHubAPI
 from .sensor import  SmartHubDataUpdateCoordinator
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_POLL_INTERVAL
 
 from datetime import timedelta
 
@@ -62,7 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = SmartHubDataUpdateCoordinator(
         hass=hass,
         api=api,
-        update_interval=timedelta(minutes=config.get("poll_interval")),
+        update_interval=timedelta(minutes=config.get("poll_interval", DEFAULT_POLL_INTERVAL)),
         config_entry=entry,
     )
     await coordinator.async_config_entry_first_refresh()


### PR DESCRIPTION
<!-- PULL_REQUEST_TEMPLATE.md -->
## 🏷️ Change Type
- [ ] 🛠 **Breaking Change** (This is incompatible with previous versions)
- [ ] 🎉 **New Feature** (Adds new functionality)
- [x] 🐛 **Bug Fix** (Fixes incorrect behavior)
- [ ] ⚡ **Performance Improvement** (Improves speed/efficiency)
- [ ] 🔧 **Maintenance** (Code cleanup, docs, dependencies)

## 🚀 Release Strategy
- [ ] **Force Major Release** (Check this if you want to increment the Major version, e.g., 1.x.y -> 2.a.b)
> *If unchecked, the release version will be automatically determined: Minor bump if it's a new month, otherwise Patch bump.*

## 📝 Description

Fixes #68.

Config entries created before `poll_interval` was added to the config flow (PR #53) do not have the key in `entry.data`. On every restart, `async_setup_entry` crashed with:

```
TypeError: unsupported type for timedelta minutes component: NoneType
```

at `__init__.py:65`, where `config.get("poll_interval")` returned `None`.

This PR provides a default by reusing `DEFAULT_POLL_INTERVAL` (already defined in `const.py` as 360 minutes / 6 hours) — the same value the config flow already uses for new entries. This matches the pattern already in use a few lines above for `timezone` and `mfa_totp`.

Diff:

```diff
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_POLL_INTERVAL
 ...
-        update_interval=timedelta(minutes=config.get("poll_interval")),
+        update_interval=timedelta(minutes=config.get("poll_interval", DEFAULT_POLL_INTERVAL)),
```

## 📋 Additional Notes

Verified locally on a real legacy config entry (HAOS Core 2026.5.1, integration 2.1.4) — after applying this patch and restarting, the integration loads cleanly and the data coordinator runs as expected.

A more thorough fix would be an `async_migrate_entry` that backfills `poll_interval` into `entry.data` and bumps `minor_version`, so the field is visible in the entry storage; happy to follow up with that in a separate PR if you'd prefer that path.
