### PR TITLE
fix: route flowDirection 'TOTAL' meters to forward_series

### DIFF
--- a/custom_components/smarthub/api.py
+++ b/custom_components/smarthub/api.py
@@ -36,6 +36,7 @@ class ParseType(StrEnum):
     FORWARD = "FORWARD"
     NET = "NET"
     RETURN = "RETURN"
+    TOTAL = "TOTAL"
 
 class Aggregation(StrEnum):
     HOURLY = "HOURLY"
@@ -213,7 +214,7 @@ class SmartHubAPI:
                       # assume forward is default if not present
                       flow_direction = meter.get("flowDirection", ParseType.FORWARD)
                       match flow_direction:
-                        case ParseType.FORWARD:
+                        case ParseType.FORWARD | ParseType.TOTAL:
                           forward_series = meter["seriesId"]
                         case ParseType.NET:
                           net_series = meter["seriesId"]


### PR DESCRIPTION
<!-- PULL_REQUEST_TEMPLATE.md -->
## 🏷️ Change Type
- [ ] 🛠 **Breaking Change** (This is incompatible with previous versions)
- [ ] 🎉 **New Feature** (Adds new functionality)
- [x] 🐛 **Bug Fix** (Fixes incorrect behavior)
- [ ] ⚡ **Performance Improvement** (Improves speed/efficiency)
- [ ] 🔧 **Maintenance** (Code cleanup, docs, dependencies)

## 🚀 Release Strategy
- [ ] **Force Major Release** (Check this if you want to increment the Major version, e.g., 1.x.y -> 2.a.b)
> *If unchecked, the release version will be automatically determined: Minor bump if it's a new month, otherwise Patch bump.*

## 📝 Description

Fixes #70 (and addresses the underlying data-flow bug from #62, which only had its crash symptom fixed).

NISC-based SmartHub deployments report a single ELECTRIC meter with `flowDirection: 'TOTAL'` (gross consumption) rather than `'FORWARD'`. The `parse_usage()` `match` statement only handled `FORWARD` / `NET` / `RETURN`, so `TOTAL` fell to the wildcard arm; `forward_series` stayed `""` and the downstream series-name matching loop never matched the meter's `seriesId`. As a result, `parsed_response["USAGE"]` was never populated and the integration silently skipped writing hourly + daily long-term statistics for these accounts.

The live monthly entity continued to update because the MONTHLY API response apparently lacks per-meter `flowDirection`, so the `FORWARD` default kicks in and the parser succeeds. Only hourly and daily statistics broke.

### Diff

```diff
 class ParseType(StrEnum):
     FORWARD = "FORWARD"
     NET = "NET"
     RETURN = "RETURN"
+    TOTAL = "TOTAL"

     match flow_direction:
-      case ParseType.FORWARD:
+      case ParseType.FORWARD | ParseType.TOTAL:
         forward_series = meter["seriesId"]
```

For non-solar accounts `TOTAL` is just gross consumption — equivalent to `FORWARD` for our purposes. Solar accounts still have separate `NET` / `RETURN` meters and that path is unchanged.

## 📋 Additional Notes

The same fix exists in `cranksecurity/ha-smarthub-energy-sensor:master` (alongside additional unrelated multi-industry refactoring). This PR cherry-picks just the surgical 2-line change so it can be reviewed and merged in isolation.

Verified locally on a NISC TOTAL-meter account (HA Core 2026.5.1, integration 2.1.4): post-patch, `parse_usage` now routes TOTAL to `forward_series`, `parsed_response["USAGE"]` populates, and hourly/daily long-term statistics resume backfilling on the next coordinator refresh (the 90-day historical-import path covers the gap).

No new tests added — the repo doesn't appear to have unit-test coverage for `parse_usage`. Happy to add one if maintainers want a fixture for `TOTAL`-shaped responses.
