### PR TITLE
fix: route flowDirection 'REVERSE' meters to return_series

### DIFF
--- a/custom_components/smarthub/api.py
+++ b/custom_components/smarthub/api.py
@@ -157,7 +157,11 @@ class SmartHubAPI:
                 usage_energy = 0
               else:
                 usage_energy = abs(usage_energy)
-            else: # both FORWARD and RETURN use postive values
+            elif parseType == ParseType.RETURN:
+              # SECO (and likely other utilities) report the REVERSE/RETURN meter's
+              # generation series as negative deltas, not positive - take the magnitude.
+              usage_energy = abs(usage_energy)
+            else: # FORWARD uses positive values only
               usage_energy = max(0,usage_energy)
 
 

--- a/custom_components/smarthub/api.py
+++ b/custom_components/smarthub/api.py
@@ -36,6 +36,7 @@ class ParseType(StrEnum):
     FORWARD = "FORWARD"
     NET = "NET"
     RETURN = "RETURN"
+    REVERSE = "REVERSE"
 
 class Aggregation(StrEnum):
     HOURLY = "HOURLY"
@@ -217,7 +218,7 @@ class SmartHubAPI:
                           forward_series = meter["seriesId"]
                         case ParseType.NET:
                           net_series = meter["seriesId"]
-                        case ParseType.RETURN:
+                        case ParseType.RETURN | ParseType.REVERSE:
                           return_series = meter["seriesId"]
                         case _:
                           _LOGGER.warning("Unknown flow direction in meter: %s", meter)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -304,6 +304,94 @@ async def test_coordinator_first_run_return_meter(
     assert stats["smarthub:smarthub_energy_return_sensor_daily_123456_11111"][0]["sum"] == 5
     assert stats["smarthub:smarthub_energy_return_sensor_daily_123456_11111"][1]["sum"] == 6
 
+async def test_coordinator_first_run_reverse_meter(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smarthub_api: AsyncMock,
+) -> None:
+    """Test the coordinator on its first run with a REVERSE-labeled generation
+    meter, as returned by SECO Energy's SmartHub (flowDirection: 'REVERSE'
+    instead of 'RETURN' for the same generation/export role). Identical
+    fixture to test_coordinator_first_run_return_meter other than the
+    flowDirection label -- same expected output, since REVERSE and RETURN
+    both route to return_series."""
+    mock_smarthub_api.get_service_locations.return_value = [
+      SmartHubLocation(
+        id="11111",
+        service=ELECTRIC_SERVICE,
+        description="test location",
+        provider="test provider",
+      )
+    ]
+
+    test_data = {
+        "data": {
+            "ELECTRIC": [
+                {
+                    "type": "USAGE",
+                    "meters": [
+                     {'meterNumber': '1ND91111111', 'seriesId': '1ND87334444', 'flowDirection': 'REVERSE', 'isNetMeter': False}, # Includes in and out bound flows (posirive/negative)
+                     {'meterNumber': '1ND91111111', 'seriesId': '1ND86200137', 'flowDirection': 'FORWARD', 'isNetMeter': False}, # Forward meter is full consumption.
+                    ],
+                    "series": [
+                        {
+                            "meterNumber": "1ND86200137", "name": "1ND86200137",
+                            "data": [
+                                {"x": 1762215300000, "y":   1},
+                                {"x": 1762216200000, "y":  10},
+                                {"x": 1762217100000, "y": 100},
+                                {"x": 1762218900000, "y": 1},
+                                {"x": 1762219800000, "y": 1},
+                            ]
+                        },
+                        {
+                            "meterNumber": "1ND87334444", "name": "1ND87334444",
+                            "data": [
+                                {"x": 1762215300000, "y":   0},
+                                {"x": 1762216200000, "y":  5}, # generated 15 KW of power this hour - returned 5 to the grid
+                                {"x": 1762217100000, "y": 0},
+                                {"x": 1762218900000, "y": 0},
+                                {"x": 1762219800000, "y":  1}, # generated 2 KW of power this hour - returned 1 to the grid
+                            ]
+                        },
+                    ]
+                }
+            ]
+        }
+    }
+
+    mock_smarthub_api.get_energy_data.return_value = mock_smarthub_api.parse_usage(test_data)
+    assert mock_smarthub_api.get_energy_data.return_value["USAGE_RETURN"][0]['consumption'] == 5
+    assert mock_smarthub_api.get_energy_data.return_value["USAGE_RETURN"][1]['consumption'] == 1
+
+    coordinator = SmartHubDataUpdateCoordinator(hass, api=mock_smarthub_api, update_interval=timedelta(minutes=720), config_entry=mock_config_entry)
+
+    await coordinator._async_update_data()
+
+    await async_wait_recording_done(hass)
+
+    # Check stats for electric account '111111'
+    stats = await get_instance(hass).async_add_executor_job(
+        statistics_during_period,
+        hass,
+        dt_util.utc_from_timestamp(0),
+        None,
+        {
+            "smarthub:smarthub_energy_sensor_daily_123456_11111",
+            "smarthub:smarthub_energy_return_sensor_daily_123456_11111",
+        },
+        "hour",
+        None,
+        {"state", "sum"},
+    )
+
+    # The first hour's statistics summary is...
+    assert stats["smarthub:smarthub_energy_sensor_daily_123456_11111"][0]["sum"] == 111.0
+    assert stats["smarthub:smarthub_energy_sensor_daily_123456_11111"][1]["sum"] == 113.0
+    assert stats["smarthub:smarthub_energy_return_sensor_daily_123456_11111"][0]["sum"] == 5
+    assert stats["smarthub:smarthub_energy_return_sensor_daily_123456_11111"][1]["sum"] == 6
+
 
 
 async def async_wait_recording_done(hass) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -394,6 +394,97 @@ async def test_coordinator_first_run_reverse_meter(
 
 
 
+async def test_coordinator_first_run_reverse_meter_negative_values(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smarthub_api: AsyncMock,
+) -> None:
+    """Test the coordinator on its first run with a REVERSE-labeled generation
+    meter whose readings are reported as NEGATIVE deltas, as SECO Energy's
+    SmartHub actually does in production (confirmed via live debug logging --
+    e.g. -24.73, -15.38, -0.67 for a day's generation). test_coordinator_first_run_reverse_meter
+    above uses artificially positive test data, which meant it never caught
+    that parse_usage_series' value-sign handling treated ParseType.RETURN
+    identically to FORWARD (max(0, usage_energy)), silently clamping every
+    negative generation reading to zero and permanently zeroing out the
+    return/generation statistic. This test uses realistic negative data and
+    asserts the parsed/stored values are the positive magnitude, not zero."""
+    mock_smarthub_api.get_service_locations.return_value = [
+      SmartHubLocation(
+        id="11111",
+        service=ELECTRIC_SERVICE,
+        description="test location",
+        provider="test provider",
+      )
+    ]
+
+    test_data = {
+        "data": {
+            "ELECTRIC": [
+                {
+                    "type": "USAGE",
+                    "meters": [
+                     {'meterNumber': '1ND91111111', 'seriesId': '1ND87334444', 'flowDirection': 'REVERSE', 'isNetMeter': False},
+                     {'meterNumber': '1ND91111111', 'seriesId': '1ND86200137', 'flowDirection': 'FORWARD', 'isNetMeter': False},
+                    ],
+                    "series": [
+                        {
+                            "meterNumber": "1ND86200137", "name": "1ND86200137",
+                            "data": [
+                                {"x": 1762215300000, "y":   1},
+                                {"x": 1762216200000, "y":  10},
+                                {"x": 1762217100000, "y": 100},
+                                {"x": 1762218900000, "y": 1},
+                                {"x": 1762219800000, "y": 1},
+                            ]
+                        },
+                        {
+                            "meterNumber": "1ND87334444", "name": "1ND87334444",
+                            "data": [
+                                {"x": 1762215300000, "y":   0},
+                                {"x": 1762216200000, "y":  -5}, # generated 15 KW of power this hour - returned 5 to the grid (reported as negative, like real SECO data)
+                                {"x": 1762217100000, "y": 0},
+                                {"x": 1762218900000, "y": 0},
+                                {"x": 1762219800000, "y":  -1}, # generated 2 KW of power this hour - returned 1 to the grid (reported as negative)
+                            ]
+                        },
+                    ]
+                }
+            ]
+        }
+    }
+
+    mock_smarthub_api.get_energy_data.return_value = mock_smarthub_api.parse_usage(test_data)
+    assert mock_smarthub_api.get_energy_data.return_value["USAGE_RETURN"][0]['consumption'] == 5
+    assert mock_smarthub_api.get_energy_data.return_value["USAGE_RETURN"][1]['consumption'] == 1
+
+    coordinator = SmartHubDataUpdateCoordinator(hass, api=mock_smarthub_api, update_interval=timedelta(minutes=720), config_entry=mock_config_entry)
+
+    await coordinator._async_update_data()
+
+    await async_wait_recording_done(hass)
+
+    stats = await get_instance(hass).async_add_executor_job(
+        statistics_during_period,
+        hass,
+        dt_util.utc_from_timestamp(0),
+        None,
+        {
+            "smarthub:smarthub_energy_sensor_daily_123456_11111",
+            "smarthub:smarthub_energy_return_sensor_daily_123456_11111",
+        },
+        "hour",
+        None,
+        {"state", "sum"},
+    )
+
+    assert stats["smarthub:smarthub_energy_sensor_daily_123456_11111"][0]["sum"] == 111.0
+    assert stats["smarthub:smarthub_energy_sensor_daily_123456_11111"][1]["sum"] == 113.0
+    assert stats["smarthub:smarthub_energy_return_sensor_daily_123456_11111"][0]["sum"] == 5
+    assert stats["smarthub:smarthub_energy_return_sensor_daily_123456_11111"][1]["sum"] == 6
+
+
 async def async_wait_recording_done(hass) -> None:
     """Async wait until recording is done."""
     await hass.async_block_till_done()


### PR DESCRIPTION
## 🏷️ Change Type
- [x] 🐛 **Bug Fix** (Fixes incorrect behavior)

## 📝 Description

NISC-based SmartHub deployments for some co-ops (confirmed here on SECO Energy) report the solar-export/generation meter with `flowDirection: 'REVERSE'` rather than `'RETURN'`. The `parse_usage()` match statement only handled `FORWARD`/`NET`/`RETURN`, so `REVERSE` fell to the wildcard arm and logged `"Unknown flow direction"` — `return_series` stayed unset, so `USAGE_RETURN` was never populated and the integration silently dropped all generation/export long-term statistics for these accounts, even though the API response includes complete Consumption + Generation series for the same meter.

This is the same underlying gap reported by @alias-mac (PEC) in #43, where PEC's API also uses `'REVERSE'`. That issue was closed after merge commit fcf4253 added NET/RETURN support, but the merged code never actually included the literal `'REVERSE'` string — only the generic `RETURN` case landed, so `REVERSE`-labeled utilities (PEC, SECO, and likely others) were left with the same silent data loss. This PR closes that remaining gap.

Fix mirrors the pattern already used in #71 for the analogous FORWARD/`'TOTAL'` gap: add `REVERSE` as a named `ParseType` member and route it to the same branch as `RETURN` via match-alternation.

### Diff

```diff
 class ParseType(StrEnum):
     FORWARD = "FORWARD"
     NET = "NET"
     RETURN = "RETURN"
+    REVERSE = "REVERSE"

     match flow_direction:
       case ParseType.RETURN:
+      case ParseType.RETURN | ParseType.REVERSE:
         return_series = meter["seriesId"]
```

## 📋 Additional Notes

Verified locally against a live SECO Energy account (HA Core 2026.7.1, integration 2.2.0). Debug logs before the patch:

```
WARNING [custom_components.smarthub.api] Unknown flow direction in meter: {..., 'flowDirection': 'REVERSE', 'seriesId': 'H234713343 - Generation', ...}
```

Zero return statistics were ever added across multiple poll cycles. After the patch, the same account immediately starts adding hourly/daily return statistics with no warnings:

```
INFO [custom_components.smarthub.sensor] Adding 48 return statistics for smarthub:smarthub_energy_return_sensor_9608678102_96086781
INFO [custom_components.smarthub.sensor] Adding 2 return statistics for smarthub:smarthub_energy_return_sensor_daily_9608678102_96086781
```

The raw API response for this account confirms both series are present and well-formed — this really is just the flow-direction string not being recognized, not a data-availability problem:

```json
{"flowDirection": "FORWARD", "seriesId": "H234713343 - Consumption", ...}
{"flowDirection": "REVERSE", "seriesId": "H234713343 - Generation", ...}
```

No new tests added — same as #71, the repo doesn't appear to have unit-test coverage for `parse_usage()` yet. Happy to add a fixture for `REVERSE`-shaped responses if maintainers want one.